### PR TITLE
Fix image tag overwriting

### DIFF
--- a/jukebox/src/components/tag_mapper.rs
+++ b/jukebox/src/components/tag_mapper.rs
@@ -61,7 +61,7 @@ impl TagMapper {
         let content = match fs::read_to_string(&self.path) {
             Ok(cnt) => cnt,
             Err(err) if err.kind() == std::io::ErrorKind::NotFound => {
-                debug!("No tag mapper configuration found");
+                warn!("No tag mapper configuration found at {}", self.path.display());
                 return Ok(());
             }
             Err(err) => {

--- a/manifests/helm/rpi-jukebox/internal/defaults/00-defaults.yaml
+++ b/manifests/helm/rpi-jukebox/internal/defaults/00-defaults.yaml
@@ -4,4 +4,4 @@ monitoring: {}
 jukebox:
   image:
     repo: mtesseract/rpi-jukebox
-    tag: latest
+    tag: main

--- a/manifests/helm/rpi-jukebox/templates/_helpers.tpl
+++ b/manifests/helm/rpi-jukebox/templates/_helpers.tpl
@@ -1,8 +1,8 @@
 {{- define "init" -}}
   {{- if not .initialized -}}
-    {{- $conf := .Files.Get "internal/defaults/00-defaults.yaml" | fromYaml -}}
+    {{- $defaultConf := .Files.Get "internal/defaults/00-defaults.yaml" | fromYaml -}}
+    {{- $conf := merge .Values $defaultConf -}}
     {{- $_ := set $conf "namespace" .Release.Namespace -}}
-    {{- $_ := set . "conf" (merge $conf .Values) -}}
 	{{- $jukeboxImageRepo := dig "jukebox" "image" "repo" "" $conf -}}
 	{{- $jukeboxImageTag := dig "jukebox" "image" "tag" "" $conf -}}
 	{{- $jukeboxImageDigest := dig "jukebox" "image" "digest" "" $conf -}}
@@ -12,6 +12,7 @@
 	{{- end }}
 	{{- $_ := set $conf "jukeboxImageRef" $jukeboxImageRef -}}
     {{- $_ := set . "initialized" true -}}
+    {{- $_ := set . "conf" $conf -}}
   {{- end -}}
 {{- end -}}
 


### PR DESCRIPTION
Previously the defaulting logic was broken so that it was not possible to specify the image tag during Helm installation.
This PR fixes the logic.
